### PR TITLE
Autoloading on package install with quelpa

### DIFF
--- a/ron-mode.el
+++ b/ron-mode.el
@@ -72,6 +72,7 @@
 
 ;;;; Footer
 
+;;;###autoload
 (define-derived-mode ron-mode prog-mode "ron-mode"
   "Major mode for editing RON files"
   (setq font-lock-defaults '((ron-font-lock-keywords)))
@@ -80,6 +81,9 @@
   (setq tab-width ron-mode-indent-offset)
   (setq indent-line-function 'ron-indent-line)  
   (setq indent-tabs-mode nil))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.ron" . ron-mode))
 
 (provide 'ron-mode)
 


### PR DESCRIPTION
When installed using quelpa (https://github.com/quelpa/quelpa), the ron-mode option wasn't available, this fixes the issue and adds autoloading when opening a file. 
From my (basic) understanding of quelpa it uses packages.el behind the scenes. These changes should then also be available when the package is installed from other sources like melpa.